### PR TITLE
fixed issue with numpy header file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ if "--cython" in sys.argv:
 if cython:
     from Cython.Build import cythonize
     extensions = cythonize([Extension("metameric.core.metric",
-                                      ["metameric/core/metric.pyx"])],
+                                      ["metameric/core/metric.pyx"],include_dirs=[np.get_include()])],
                            include_path=[np.get_include()])
 else:
     extensions = [Extension("metameric.core.metric",


### PR DESCRIPTION
Referring to the issue: #2 
I tried a fresh install on a clean Linux VM on Google Cloud with Ubuntu 18.04 LTS installed. The same error persisted. It seems that adding the line alone was not enough as the `--cython` argument is compulsory. that change will be added in a future PR after experimenting. And as mentioned in the metameric command has to be run in a folder away from the source folder (took me a while to notice that 😄 ) 